### PR TITLE
Add a Readme for the Cookbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
 # Ripple BlobVault Cookbook
 A Chef Cookbook which installs and configures the Ripple
 BlobVault server.
+
+## Canonical Repository
+The canonical repository for this project is located at https://github.com/ripple/ripple-blobvault-cookbook

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# Ripple BlobVault Cookbook
+A Chef Cookbook which installs and configures the Ripple
+BlobVault server.


### PR DESCRIPTION
The cookbook should have a README file which defines exactly what the cookbook does and where users may find the canonical version.
